### PR TITLE
Fix typos in documentation

### DIFF
--- a/chapter_3_concepts/Readme.md
+++ b/chapter_3_concepts/Readme.md
@@ -1,2 +1,2 @@
 ## 学习补充说明
-rust的运行模式主要有两种，debug模式(cargo run) 和release 模式 (cargo run --release) 不同模式会导致程序运行出不同的结果, 比如溢出, debug模式溢出会有报错, 而release会补码
+rust的运行模式主要有两种：debug模式（`cargo run`）和release模式（`cargo run --release`）。不同模式会导致程序运行出不同的结果，比如溢出。debug模式溢出会报错，而release模式会采用补码处理。

--- a/chapter_3_concepts/Readme.md
+++ b/chapter_3_concepts/Readme.md
@@ -1,2 +1,2 @@
 ## 学习补充说明
-rust的运行模式主要有两种：debug模式（`cargo run`）和release模式（`cargo run --release`）。不同模式会导致程序运行出不同的结果，比如溢出。debug模式溢出会报错，而release模式会采用补码处理。
+rust的运行模式主要有两种: debug模式 (`cargo run`) 和release模式 (`cargo run --release`). 不同模式会导致程序运行出不同的结果, 比如溢出. debug模式溢出会报错, 而release模式会采用补码处理.

--- a/chapter_4_ownership/Readme .md
+++ b/chapter_4_ownership/Readme .md
@@ -38,7 +38,7 @@
     let s = String::from("hello");
 ```
 
-这两个::是运算符, 允许将特定的`from`函数置于String类型的命名空间(namespace)下. 而不需要使用类似string_from这样的函数名. 这个之后在`方法语法(Methid Syntax)`部分会讲到这个语法, 在`路径用于引用模块树中的项`中会讲到命名空间.
+这两个::是运算符, 允许将特定的`from`函数置于String类型的命名空间(namespace)下, 而不需要使用类似string_from这样的函数名。这个之后在`方法语法(Method Syntax)`部分会讲到这个语法, 在`路径用于引用模块树中的项`中会讲到命名空间。
 **可以**修改此类字符串:
 ```rust
     let mut s = String::from("hello");

--- a/chapter_4_ownership/Readme .md
+++ b/chapter_4_ownership/Readme .md
@@ -38,7 +38,7 @@
     let s = String::from("hello");
 ```
 
-这两个::是运算符, 允许将特定的`from`函数置于String类型的命名空间(namespace)下, 而不需要使用类似string_from这样的函数名. 这个之后在`方法语法(Method Syntax)`部分会讲到这个语法, 在`路径用于引用模块树中的项`中会讲到命名空间.
+这两个::是运算符, 允许将特定的 `from` 函数置于 String 类型的命名空间 (namespace) 下, 而不需要使用类似 string_from 这样的函数名. 这个之后在 `方法语法 (Method Syntax)` 部分会讲到这个语法, 在 `路径用于引用模块树中的项` 中会讲到命名空间.
 **可以**修改此类字符串:
 ```rust
     let mut s = String::from("hello");

--- a/chapter_4_ownership/Readme .md
+++ b/chapter_4_ownership/Readme .md
@@ -38,7 +38,7 @@
     let s = String::from("hello");
 ```
 
-这两个::是运算符, 允许将特定的`from`函数置于String类型的命名空间(namespace)下, 而不需要使用类似string_from这样的函数名。这个之后在`方法语法(Method Syntax)`部分会讲到这个语法, 在`路径用于引用模块树中的项`中会讲到命名空间。
+这两个::是运算符, 允许将特定的`from`函数置于String类型的命名空间(namespace)下, 而不需要使用类似string_from这样的函数名. 这个之后在`方法语法(Method Syntax)`部分会讲到这个语法, 在`路径用于引用模块树中的项`中会讲到命名空间.
 **可以**修改此类字符串:
 ```rust
     let mut s = String::from("hello");


### PR DESCRIPTION
## Summary
- fix `Methid` -> `Method` typo in ownership notes
- clarify release mode explanation and formatting in concept notes

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684bfb20e390832b84052299a0cb7e1d